### PR TITLE
Removed error code from cache:flush command

### DIFF
--- a/src/Aequasi/Bundle/CacheBundle/Command/CacheFlushCommand.php
+++ b/src/Aequasi/Bundle/CacheBundle/Command/CacheFlushCommand.php
@@ -42,7 +42,5 @@ class CacheFlushCommand extends ContainerAwareCommand
         $service = $this->getContainer()
                         ->get( $serviceName );
         $service->flushAll();
-
-        return 1;
     }
 } 


### PR DESCRIPTION
"return 1" at the end of the command means "error code 1". If everything went fine, null or 0 should be return.

This is an issue when cache:flush is added to composer postInstall commands, because an error code stops the install procedure.
